### PR TITLE
Fix special case in roxygen pattern

### DIFF
--- a/grammars/r.cson
+++ b/grammars/r.cson
@@ -440,7 +440,7 @@
   'roxygen': {
     'patterns': [
       {
-        'begin': "^(#\\')\\s*"
+        'begin': "^(#\\'[^\\S\\n]*)"
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.r'


### PR DESCRIPTION
Currently roxygen matches `^(#\\'\\s*)`, which matches all whitespace after `#'` including newlines. This misses the following case:

```r
#' @param xyz abcde
#'
any <- function(){}  # <--- this line is not highlighted as function
```

Pattern fixes excludes newline from whitespace by double negation `[^\S\n]`